### PR TITLE
fix: patch docker-compose.yml for Elastic 9.x compatibility

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -6,6 +6,20 @@
     single_branch: true
     force: true
 
+- name: Fix elastic-agent image path for Elastic 9.x (beats namespace removed)
+  ansible.builtin.replace:
+    path: "{{ ludus_elastic_container_install_path }}/docker-compose.yml"
+    regexp: 'docker\.elastic\.co/beats/elastic-agent:'
+    replace: 'docker.elastic.co/elastic-agent/elastic-agent:'
+  when: ludus_elastic_stack_version is version("9.0.0", ">=")
+
+- name: Fix Kibana health check for HTTP/2 (Elastic 9.x uses HTTP/2, not HTTP/1.1)
+  ansible.builtin.replace:
+    path: "{{ ludus_elastic_container_install_path }}/docker-compose.yml"
+    regexp: "grep -q 'HTTP/1\\.1 302 Found'"
+    replace: "grep -q '302'"
+  when: ludus_elastic_stack_version is version("9.0.0", ">=")
+
 - name: Copy the .env template to the host
   ansible.builtin.template:
     src: files/env.example


### PR DESCRIPTION
Two breaking changes in Elastic 9.x break this role when ludus_elastic_stack_version >= 9.0.0:

1. elastic-agent Docker image namespace changed
   - Old: docker.elastic.co/beats/elastic-agent:<version>
   - New: docker.elastic.co/elastic-agent/elastic-agent:<version>
   - Without this fix: docker pull fails with 'not found'

2. Kibana health check fails on HTTP/2
   - The docker-compose.yml healthcheck greps for 'HTTP/1.1 302 Found'
   - Kibana 9.x uses HTTP/2 and returns 'HTTP/2 302' (no match)
   - Result: Kibana stays 'unhealthy' indefinitely, fleet-server (which depends_on kibana: condition: service_healthy) never starts, elastic-container.sh times out after 20 minutes

Both patches use ansible.builtin.replace on docker-compose.yml after the git clone, conditioned on ludus_elastic_stack_version >= 9.0.0, so they are backwards-compatible with pre-9.x deployments.